### PR TITLE
Hotfix/inline mention range bug

### DIFF
--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -664,18 +664,23 @@ class Mention {
 
     this.cursorPos = range.index;
     const textBeforeCursor = this.getTextBeforeCursor();
+
+    const textOffset = Math.max(0, this.cursorPos - this.options.maxChars);
+    const textPrefix = textOffset ? this.quill.getText(textOffset - 1, textOffset) : '';
+
     const { mentionChar, mentionCharIndex } = getMentionCharIndex(
       textBeforeCursor,
       this.options.mentionDenotationChars
     );
 
     if (
-        hasValidMentionCharIndex(
-          mentionCharIndex,
-          textBeforeCursor,
-          this.options.isolateCharacter
-        )
-      ) {
+      hasValidMentionCharIndex(
+        mentionCharIndex,
+        textBeforeCursor,
+        this.options.isolateCharacter,
+        textPrefix
+      )
+    ) {
       const mentionCharPos = this.cursorPos - (textBeforeCursor.length - mentionCharIndex);
       this.mentionCharPos = mentionCharPos;
       const textAfter = textBeforeCursor.substring(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -34,17 +34,20 @@ function hasValidChars(text, allowedChars) {
   return allowedChars.test(text);
 }
 
-function hasValidMentionCharIndex(mentionCharIndex, text, isolateChar) {
-  if (mentionCharIndex > -1) {
-    if (
-      isolateChar &&
-      !(mentionCharIndex === 0 || !!text[mentionCharIndex - 1].match(/\s/g))
-    ) {
-      return false;
-    }
+function hasValidMentionCharIndex(mentionCharIndex, text, isolateChar, textPrefix) {
+  if (mentionCharIndex === -1) {
+    return false;
+  }
+
+  if (!isolateChar) {
     return true;
   }
-  return false;
+
+  const mentionPrefix = mentionCharIndex
+    ? text[mentionCharIndex - 1]
+    : textPrefix;
+
+  return !mentionPrefix || !!mentionPrefix.match(/\s/);
 }
 
 export {


### PR DESCRIPTION
Fix bug where the isolated mention character check could return wrong result.

Consider these settings:
```js
{
    allowChars: /^[a-zA-Z0-9.]+$/,
    maxChars: 8,
    isolateCharacter: true,
}
```

If the quill text was `tim@owow.i`. The `getTextBeforeCursor` method would return the last 8 characters before the cursor, which would be `m@owow.i`. The `hasValidMentionCharIndex` would get the `@` index (which is 1) and check if it was isolated (which it isn't). All good and well.

Now I type an extra letter so the quill text becomes `tim@owow.io`, the last 8 characters would now be `@owow.io`. The `hasValidMentionCharIndex` would get the `@` index (which is now 0) and return `true` meaning it thinks it's an isolated mention whilst the bigger scope shows it is not isolated.

My fix gets the one character before the `getTextBeforeCursor` string (if there is anything before it) and passes it to the `hasValidMentionCharIndex` function. Now the function checks IF the `@` index is 0, the one character mention character prefix is either an empty string (meaning the text range is the beginning of the Quill) or is a whitespace character. Both cases mean the mention character is isolated. If neither cases are true, the character is not isolated.
