### PR TITLE
Bind all option-functions so they have a reasonable context

### DIFF
--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -73,6 +73,13 @@ class Mention {
         : this.options.dataAttributes
     });
 
+    //Bind all option-functions so they have a reasonable context
+    for(let o in this.options) {
+      if (typeof this.options[o] === 'function') {
+        this.options[o] = this.options[o].bind(this);
+      }
+    }
+
     //create mention container
     this.mentionContainer = document.createElement("div");
     this.mentionContainer.className = this.options.mentionContainerClass


### PR DESCRIPTION
In my `onSelect` method, I sometimes want to insert pure text instead of the _mention_. This wasn't possible, since there was no (reasonable) `this`. Now you can do e.g. the following:

```
onSelect: function (item, insertItem) {
    if (item.whatEver) {
        const insertAtPos = this.mentionCharPos;
        this.quill.deleteText(
            this.mentionCharPos,
            this.cursorPos - this.mentionCharPos,
            Quill.sources.USER
        );

        this.quill.insertText(insertAtPos, item.whatEver);
    } else {
        insertItem(item);
    }
}
```