### PR TITLE
Use native scrollIntoView method so it correctly accounts for paddings and scroll-margins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quill-mention",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quill-mention",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "quill": "^1.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quill-mention",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quill-mention",
-      "version": "4.0.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "quill": "^1.3.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-mention",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "@mentions for the Quill rich text editor",
   "homepage": "https://quill-mention.com/",
   "main": "dist/quill.mention.csj.js",

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -241,20 +241,10 @@ class Mention {
     );
 
     if (scrollItemInView) {
-      const itemHeight =
-        this.mentionList.childNodes[this.itemIndex].offsetHeight;
-      const itemPos = this.mentionList.childNodes[this.itemIndex].offsetTop;
-      const containerTop = this.mentionContainer.scrollTop;
-      const containerBottom = containerTop + this.mentionContainer.offsetHeight;
-
-      if (itemPos < containerTop) {
-        // Scroll up if the item is above the top of the container
-        this.mentionContainer.scrollTop = itemPos;
-      } else if (itemPos > containerBottom - itemHeight) {
-        // scroll down if any part of the element is below the bottom of the container
-        this.mentionContainer.scrollTop +=
-          itemPos - containerBottom + itemHeight;
-      }
+      this.mentionList.childNodes[this.itemIndex].scrollIntoView({
+        behaviour: "smooth",
+        block: "nearest"
+      })
     }
   }
 

--- a/src/quill.mention.js
+++ b/src/quill.mention.js
@@ -243,8 +243,8 @@ class Mention {
     if (scrollItemInView) {
       this.mentionList.childNodes[this.itemIndex].scrollIntoView({
         behaviour: "smooth",
-        block: "nearest"
-      })
+        block: "nearest",
+      });
     }
   }
 


### PR DESCRIPTION
The DIY scroll into view calculations don't correctly account for paddings and scroll-margins. By using the native [scrollInfoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method elements won't be clipped when they are styled by the users.

| Before | After |
| ---- | ----|
| ![scrollIntoView-Before](https://github.com/quill-mention/quill-mention/assets/11800807/f8494913-afe9-4929-afa5-85dcc63cf000) |  ![scrollIntoView-After](https://github.com/quill-mention/quill-mention/assets/11800807/a94f274e-ad43-4c6a-a520-028dd38499c5) |


