### PR TITLE
NPM deploy script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Install npm
+        uses: actions/setup-node@v3
+        with:
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          git config --local user.email "quill"
+          git config --local user.name "quill-mentions"
+          npm publish --provenance --access public
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          git commit -a -m "v${PACKAGE_VERSION}"
+          git push

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "clean": "rimraf dist",
-    "start": "concurrently \"rollup -c -w\" \"serve docs\"",
     "build": "rollup -c",
+    "clean": "rimraf dist",
     "lint": "prettier -w src/",
+    "start": "concurrently \"rollup -c -w\" \"serve docs\"",
     "test": "ava"
   },
   "ava": {


### PR DESCRIPTION
Automatically deploys new versions to npm on updates to master

Todo:
- [x] Push the code that hasn't been pushed up from my local machine for months for no reason
- [ ] Set `NPM_TOKEN` into repo settings under "Github Actions" section for testing account
- [ ] Debug script (a lot of force pushing to this branch)
- [ ] Set `NPM_TOKEN` into repo settings under "Github Actions" section for public account
- [ ] Make sure it actually works properly and didn't bork up the public package which would be bad
- [ ] ...
- [ ] Profit!
