### PR TITLE
Github Actions npm deploy script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - master
+  release:
+    types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Install npm
+        uses: actions/setup-node@v4
+        with:
+          cache-dependency-path: package-lock.json
+          cache: "npm"
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          npm config set init-author-name "quill-mention"
+          npm config set init-author-email "no-reply@quill-mention.com"
+          npm config set init-author-url "https://quill-mention.com"
+          npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
     "typescript": "^5.4.5"
   },
   "scripts": {
-    "clean": "rimraf dist",
-    "start": "concurrently \"rollup -c -w\" \"serve docs\"",
     "build": "rollup -c",
+    "clean": "rimraf dist",
     "lint": "prettier -w src/",
+    "start": "concurrently \"rollup -c -w\" \"serve docs\"",
     "test": "ava"
   },
   "ava": {


### PR DESCRIPTION
Automatically deploys new versions to npm on updates to master

For this to work, new PRs must bump the package in their branches before it is merged into master, otherwise it'll try to redeploy the previous version (which will fail).

Todo:
- [x] Push the code that hasn't been pushed up from my local machine for months for no reason
- [x] Set `NPM_TOKEN` into repo settings under Secrets -> Actions -> Repository Secret for testing account
- [x] Debug script (a lot of force pushing to the branch)
- [x] Get a successful deploy to npm and immediately delete it
- [x] Get branch ready for actual repo and not test repo (a lot of force pushing to the branch)
- [x] Set `NPM_TOKEN` into repo settings under Secrets -> Actions -> Repository Secret for MadSpindel's account
- [ ] Make sure it didn't bork up the public package which would be bad
- [ ] ...
- [ ] Profit!